### PR TITLE
Version 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This tool is **not** for making websites. For that, use `SvelteKit` or a bundler
 
 ## Getting started
 
-- Install svbuild globally by running `npm i svbuild -g` or locally (not recommended): `npm i svbuild -D`
+- Install svbuild globally by running `npm i svbuild -g` or locally: `npm i svbuild -D`
 
 - Create a folder with two subfolders: `/src` and `/out`.
 
@@ -38,7 +38,7 @@ export type Config = {
   out: string,
   /** Svelte compiler options */
   compilerOptions?: {
-    /** Whether to generate code with ES6 imports and exports Note that svbuild doesn't provide a `require()` funtion! */
+    /** Whether to generate code with ES6 imports and exports. Note that svbuild doesn't provide a `require()` funtion! */
     esm?: boolean,
     /** Developer mode */
     dev?: boolean,
@@ -51,18 +51,28 @@ export type Config = {
     /** A number that tells Svelte to break the loop if it blocks the thread for more than `loopGuardTimeout` ms. This is useful to prevent infinite loops. Only available when `dev: true` */
     loopGuardTimeout?: number
   },
+  /** Preprocessors allow for integration of different languages and features into svelte. */
+  preprocess?: PreprocessorGroup | PreprocessorGroup[]
   /** Options for the module resolver. This **must not** be defined if `compilerOptions.esm` is `false` */
   moduleOptions?: {
     /** The folder where the compiled modules are or will be built to.
-     * > Note: this path is relative to the CWD, not to the `out` directory */
-    root?: string,
+     * > Note: this path is relative to the `out` directory */
+    root?: string
     /** Whether svbuild should build all the dependencies */
-    buildModules?: boolean,
-    /** Path to the folder, from which the dependencies are taken from. Default is `./node_modules`
+    buildModules?: boolean
+    /** Path to the folder, from which the dependencies are taken from. Default is `"node_modules"`
      * @default "node_modules" */
-    modulesSrc?: string,
+    modulesSrc?: string
     /** Whether svbuild should build svelte like a regular dependency */
     buildSvelte?: boolean
+    /** Whether svbuild should preprocess module code. Can be either set to boolean, or to an object with module names as keys. */
+    usePreprocessorsWithModules?: boolean | {
+      [moduleName: string]: string
+    }
+    /** The preferred type of the `exports` field. Is usually `"browser"`, but can be set to anything else if that's causing problems */
+    preferredResolutionType?: {
+      [moduleName: string]: string
+    }
   }
 }
 ```
@@ -71,18 +81,17 @@ An example config file looks like this:
 
 ```js
 /**
- * @type {import('../config').Config}
+ * @type {import('svbuild/types').Config}
  */
 const config = {
   src: './svelte',
   out: './out',
   compilerOptions: {
     esm: true,
-    dev: true,
-    sveltePath: './out/modules/svelte'
+    dev: true
   },
   moduleOptions: {
-    root: './out/modules',
+    root: 'modules',
     buildModules: true,
     buildSvelte: true,
     modulesSrc: 'node_modules'
@@ -98,25 +107,17 @@ This is how to use the `svbuild` tool
 
 `svbuild`
 
-- `-s, --src <path>` - Source dir, overrides `config.src`
-
-- `-o, --out <path>` - Output, overrides `config.out`
-
 - `-c, --config <path>` - Path to the configuration file (default: `./svbuild.config.js`)
 
 - `-v, --verbose` - Log internal information
 
-- `-R, --rebuild` - Usually, svbuild doesn't build the same module twice. This option makes it forcefully rebuild all dependencies.
+- `-w, --watch` - Watch the src directory for changes.
 
-`svbuild watch` - Watches the `src` directory for changes and rebuilds changed files
-
-- `--src, --out, --config, --verbose` is the same as `svbuild`
-
-- `-b, --no-build` - Don't build the project on start.
+- `-B, --no-build` - Don't build the project at first, only works with --watch
 
 ## Limitations
 
-Currently, svbuild doesn't support preprocessors and source maps. This will probably be implemented in a next major version.
+Currently, svbuild doesn't support source maps. This will probably be implemented in a next major version.
 
 Also note that svbuild is still in beta so it can include bugs. Please report all issues on Github.
 

--- a/dist/compile.js
+++ b/dist/compile.js
@@ -1,136 +1,22 @@
 import * as _fs from "fs-extra";
-import * as pt from "path";
-import * as svelte from "svelte/compiler";
-import * as acorn from "acorn";
-import { betterJoin, prepareJSPath, resolveImport } from "./resolve.js";
-import { logger } from "./config.js";
 import c from "chalk";
+import * as svelte from "svelte/compiler";
+import * as p from "path";
+import * as acorn from "acorn";
+import { logger } from "./config.js";
+import { resolveDependency } from "./resolve.js";
 const fs = _fs.default;
-const BUILD_ERROR = c.bgRed("[BUILD ERROR]");
-export const compilationMap = {};
-const alreadyBuilt = [];
-export function includeBuiltModules(modDir) {
-    try {
-        let entries = fs.readdirSync(modDir);
-        alreadyBuilt.push(...entries);
-    }
-    catch (_) { }
-}
-export async function buildAll(dep, to, isDependency) {
-    async function dir(path, to) {
-        let entries = [];
-        try {
-            entries = await fs.readdir(path);
-        }
-        catch (e) {
-            console.error(`${BUILD_ERROR} Can't get the source of dependency "${dep}" (folder "${path}"). Check if you have it installed in modulesSrc.\nError:`, e);
-            return;
-        }
-        for (const en of entries) {
-            const enPath = betterJoin(path, en);
-            const destPath = betterJoin(to, en);
-            build(dir, enPath, destPath, (e) => {
-                console.error(`${BUILD_ERROR} Unable to build dependency "${dep}". \n  Error:`, e);
-            });
-        }
-    }
-    if (isDependency) {
-        let initialDep = dep;
-        dep = betterJoin(config.moduleOptions.modulesSrc, dep);
-        logger("Building dependency %o, path: %o", initialDep, dep);
-        await dir(dep, betterJoin(to, initialDep));
-    }
-    else {
-        logger("Compiling all from %o to %o", dep, to);
-        await dir(dep, to);
-    }
-}
-export async function build(dir, enPath, destPath, onError) {
-    try {
-        if ((await fs.lstat(enPath)).isDirectory()) {
-            await dir(enPath, destPath);
-            compilationMap[pt.normalize(enPath)] = { type: 'dir', path: destPath };
-        }
-        else if (enPath.endsWith('.svelte')) {
-            await compile(enPath, destPath + '.js');
-            compilationMap[pt.normalize(enPath)] = { type: 'svelte', path: destPath };
-        }
-        else if (enPath.endsWith('.js') || enPath.endsWith('.mjs')) {
-            const code = await modImports(destPath, await fs.readFile(enPath, 'utf-8'));
-            await fs.ensureFile(destPath);
-            await fs.writeFile(destPath, code);
-            compilationMap[pt.normalize(enPath)] = { type: 'js', path: destPath };
-        }
-        else {
-            await fs.copy(enPath, destPath, { recursive: true, overwrite: true });
-            compilationMap[pt.normalize(enPath)] = { type: 'unknown', path: destPath };
-        }
-    }
-    catch (e) {
-        onError(e);
-    }
-}
-export async function compile(from, to) {
-    const contents = await fs.readFile(from, 'utf-8');
-    let compiled;
-    try {
-        let { code } = await svelte.preprocess(contents, config.preprocess || [], { filename: pt.basename(from) });
-        compiled = svelte.compile(code, {
-            css: true,
-            accessors: config.compilerOptions.accessors,
-            immutable: config.compilerOptions.immutable,
-            loopGuardTimeout: config.compilerOptions.loopGuardTimeout,
-            generate: 'dom',
-            format: config.compilerOptions.esm ? 'esm' : 'cjs',
-            filename: pt.basename(from),
-            dev: config.compilerOptions.dev,
-            sveltePath: config.moduleOptions ? 'svelte' : config.compilerOptions.sveltePath // sveltePath is handled by svbuild
-        });
-    }
-    catch (err) {
-        if ('start' in err) {
-            let { start, frame } = err;
-            console.warn(`${c.red("[ERROR]")} in "${from}" (${start.line}:${start.column})\n ${frame.replaceAll('\n', '\n ')}`);
-        }
-        else {
-            console.warn(`${c.red("[ERROR]")} in preprocessing step:\n ${err.toString().replaceAll('\n', '\n ')}`);
-        }
-        return;
-    }
-    compiled.warnings.forEach(w => {
-        console.warn(`${c.yellow("[WARNING]")} in "${from}" (${w.start.line}:${w.start.column})\n ${w.frame.replaceAll('\n', '\n ')}
-  ${w.message.replaceAll('\n', '\n  ')}`);
-    });
-    let { code } = compiled.js;
-    if (config.moduleOptions?.buildModules) {
-        code = await modImports(to, code);
-    }
-    void async function writeCompiled() {
-        await fs.ensureFile(to);
-        await fs.writeFile(to, code);
-    }();
-}
-export async function modImports(resolveFrom, code) {
+export async function modImports(code, dependsOn) {
     const { body } = acorn.parse(code, { ecmaVersion: 'latest', sourceType: 'module' }); // as any because typescript goes nuts
     let shiftBy = 0;
     for (const node of body) {
-        // maybe should switch to recast (or magic-string) instead of this 
-        // also it would make it easier to plug it into the preprocessor instead of post-processing
+        // maybe should switch to recast (or magic-string) instead of this
         if (node.type != 'ImportDeclaration' && (node.type != 'ExportNamedDeclaration' || node.source == null))
             continue;
         const { source } = node;
         let modPath = source.value;
         let fixedString;
-        if (modPath.startsWith('.') || modPath.startsWith('/') || modPath.includes('://')) {
-            if (!modPath.endsWith('.js') && !modPath.endsWith('.mjs')) {
-                modPath += '.js';
-            }
-            fixedString = modPath;
-        }
-        else {
-            fixedString = analyseAndResolve(pt.dirname(resolveFrom), modPath);
-        }
-        logger("Converted:", modPath, "->", fixedString);
+        fixedString = await dependsOn(modPath);
         // actually no idea why 5 characters
         let cut = code.slice(source.start + shiftBy - 5, source.end + shiftBy + 5);
         let newCut = cut.replace(source.raw, `"${fixedString.replaceAll('\\', '\\\\').replaceAll('"', '\\"').replaceAll("'", "\\'")}"`);
@@ -139,38 +25,168 @@ export async function modImports(resolveFrom, code) {
     }
     return code;
 }
-/** makes all imports relative */
-function analyseAndResolve(path, dep) {
-    logger(`Analysing "${dep}" from "${path}"`);
-    if (!config.moduleOptions?.root)
-        return prepareJSPath(dep);
-    const root = pt.relative(path, config.moduleOptions.root);
-    let firstSegment = dep.split('/')[0];
-    let stripped = dep.replace(firstSegment, '').slice(1); // slice(1) removes the slash
-    if (!config.moduleOptions.buildSvelte) {
-        if (firstSegment == 'svelte') {
-            if (pt.extname(stripped) == '')
-                stripped = betterJoin(stripped, 'index.mjs');
-            logger('Imported svelte module:', betterJoin(config.compilerOptions.sveltePath, stripped));
-            return prepareJSPath(betterJoin(config.compilerOptions.sveltePath, stripped));
+export async function svelteTool(filename, contents, dependsOn, moduleName) {
+    let compiled;
+    try {
+        let code = contents;
+        const setCode = async () => code = (await svelte.preprocess(contents, config.preprocess || [], { filename })).code;
+        if (moduleName) {
+            if (typeof config.moduleOptions.usePreprocessorsWithModules == 'object') {
+                if (moduleName in config.moduleOptions.usePreprocessorsWithModules) {
+                    if (config.moduleOptions.usePreprocessorsWithModules[moduleName]) {
+                        await setCode();
+                    }
+                }
+            }
+            else if (config.moduleOptions.usePreprocessorsWithModules) {
+                await setCode();
+            }
+        }
+        else {
+            await setCode();
+        }
+        compiled = svelte.compile(code, {
+            css: true,
+            accessors: config.compilerOptions.accessors,
+            immutable: config.compilerOptions.immutable,
+            loopGuardTimeout: config.compilerOptions.loopGuardTimeout,
+            generate: 'dom',
+            format: config.compilerOptions.esm ? 'esm' : 'cjs',
+            filename,
+            dev: config.compilerOptions.dev,
+            sveltePath: config.moduleOptions ? 'svelte' : config.compilerOptions.sveltePath // sveltePath is handled by svbuild
+        });
+    }
+    catch (err) {
+        if ('start' in err) {
+            let { start, frame } = err;
+            throw `in "${filename}" (${start.line}:${start.column})\n ${frame.replaceAll('\n', '\n ')}`;
+        }
+        else {
+            throw `in preprocessing step of "${filename}":\n ${err.toString().replaceAll('\n', '\n ')}`;
         }
     }
-    let relativePathToMod = betterJoin(root, firstSegment);
-    let prePath = prepareJSPath(betterJoin(relativePathToMod, stripped));
-    if (config.moduleOptions.buildModules && !alreadyBuilt.includes(firstSegment)) {
-        void async function () {
-            try {
-                await buildAll(firstSegment, config.moduleOptions.root, true).then(() => alreadyBuilt.push(firstSegment));
-            }
-            catch (e) {
-                console.error(`${BUILD_ERROR} Unable to build "${dep}".\n  Error:`, e);
-            }
-        }();
+    compiled.warnings.forEach(w => {
+        console.warn(`${c.yellow("[WARNING]")} in "${filename}" (${w.start.line}:${w.start.column})\n ${w.frame.replaceAll('\n', '\n ')}
+  ${w.message.replaceAll('\n', '\n  ')}`);
+    });
+    let { code } = compiled.js;
+    if (config.moduleOptions?.buildModules) {
+        code = await modImports(code, dependsOn);
     }
-    if (prePath.endsWith('.js')) {
-        return prePath;
+    return { code, filename: filename + '.js' };
+}
+export async function jsTool(filename, contents, dependsOn) {
+    if (filename.endsWith('.mjs')) {
+        filename = filename.slice(0, -4) + '.js';
+    }
+    if (p.extname(filename) != '.js') {
+        filename = filename + '.js';
+    }
+    return { filename, code: await modImports(contents, dependsOn) };
+}
+export async function copyTool(filename, code) {
+    return { filename, code };
+}
+function formatPath(path) {
+    path = path.replaceAll('\\', '/');
+    if (path.startsWith('.')) {
+        return path;
+    }
+    return './' + path;
+}
+function findRelativePath(path, src, moduleName) {
+    if (path.startsWith(src)) {
+        return p.relative(src, p.dirname(path));
+    }
+    else if (!moduleName) {
+        throw `A file required that lies outside of the "src" directory. (path: ${path})`;
     }
     else {
-        return resolveImport(dep, prePath, relativePathToMod);
+        const fileModulePath = p.relative(config.moduleOptions.modulesSrc, p.dirname(path));
+        // path is outside src
+        if (!config.moduleOptions.buildModules)
+            return false;
+        return p.join(config.moduleOptions.root, fileModulePath);
+    }
+}
+export const buildMap = {};
+export async function buildFile(path, moduleName) {
+    /** In an event of a circular dependency, we shadow-compile this file and return the path of it.
+     * Then, the compilation resumes normally. */
+    let IS_PENDING;
+    path = p.normalize(path);
+    if (path in buildMap) {
+        const inMap = buildMap[path];
+        if (inMap == false) {
+            IS_PENDING = true;
+        }
+        else
+            return inMap;
+    }
+    try {
+        const relPath = findRelativePath(path, config.src, moduleName);
+        if (relPath === false)
+            return false;
+        buildMap[p.normalize(path)] = false; // pending build
+        const outPath = p.join(config.out, relPath);
+        const contents = await fs.readFile(path, 'utf-8');
+        let tool;
+        if (path.endsWith('.svelte')) {
+            tool = svelteTool;
+        }
+        else if (path.endsWith('.mjs') || path.endsWith('.js')) {
+            tool = jsTool;
+        }
+        else {
+            tool = copyTool;
+        }
+        logger("Building", c.green(path));
+        const { code, filename } = await tool(p.basename(p.relative(config.src, path)), contents, async function dependsOn(dep) {
+            logger("Dependency:", c.cyan(dep));
+            if (IS_PENDING)
+                return dep; // to prevent infinite loops
+            const resolved = await resolveDependency(path, dep);
+            logger("Resolved dependency:", resolved);
+            if (!resolved)
+                return dep; // external dependency, such as a URL
+            if (resolved.moduleName == 'svelte' && !config.moduleOptions.buildSvelte) {
+                logger("Replacing 'svelte' with `sveltePath`");
+                return dep.replace('svelte', config.compilerOptions.sveltePath);
+            }
+            const builtPath = await buildFile(resolved.path, resolved.moduleName || moduleName);
+            if (builtPath === false)
+                return dep;
+            const formattedPath = formatPath(p.relative(outPath, builtPath));
+            logger("Dependecy built, formatted path:", c.green(formattedPath));
+            return formattedPath;
+        }, moduleName);
+        const realPath = p.join(outPath, filename);
+        if (!IS_PENDING) {
+            logger("Finished building", c.green(path), "\nWriting to", c.green(realPath));
+            await fs.ensureFile(realPath);
+            await fs.writeFile(realPath, code);
+        }
+        else
+            logger("Finished shadow-building", c.green(path));
+        buildMap[p.normalize(path)] = realPath;
+        return realPath;
+    }
+    catch (err) {
+        console.error(c.red("[ERROR]"), `while trying to build "${path}":`, (err.stack ?? err) + '');
+        return false;
+    }
+}
+export async function buildAll(path) {
+    const entries = await fs.readdir(path);
+    for (const e of entries) {
+        const finalPath = p.join(path, e);
+        const stat = await fs.lstat(finalPath);
+        if (stat.isDirectory()) {
+            await buildAll(finalPath);
+        }
+        else if (stat.isFile()) {
+            await buildFile(finalPath);
+        }
     }
 }

--- a/dist/main.js
+++ b/dist/main.js
@@ -90,21 +90,4 @@ program.name("svbuild")
         });
     });
 });
-program.command("watch").description("Watches the src directory for changes")
-    .option("-c, --config <path>", "Path to the configuration file", './svbuild.config.js')
-    .option("-v, --verbose", "Log internal information")
-    .option("-B, --no-build", "Don't build everything at first")
-    .action(async ({ config: cPath, verbose, build: shouldBuild }) => {
-    console.log(process.argv, { config: cPath, verbose, build: shouldBuild });
-    await importConfig(cPath);
-    config.compilerOptions ||= Object.assign(defaultConfig.compilerOptions, config.compilerOptions);
-    if (config.moduleOptions) {
-        config.moduleOptions = Object.assign(defaultConfig.moduleOptions, config.moduleOptions);
-    }
-    global.verbose = verbose;
-    if (!(config.compilerOptions?.esm) && config.moduleOptions) {
-        console.error(`compilerOptions.esm cannot be %o with config.moduleOptions`, false);
-        process.exit(1);
-    }
-});
 program.parse();

--- a/dist/main.js
+++ b/dist/main.js
@@ -10,7 +10,7 @@ program.name("svbuild")
     .option("-c, --config <path>", "Path to the configuration file", './svbuild.config.js')
     .option("-v, --verbose", "Log internal information")
     .option("-w, --watch", "Watch the src directory for changes")
-    .option("-B, --no-build", "Don't build everything at first, only works with --watch")
+    .option("-B, --no-build", "Don't build the project at first, only works with --watch")
     .action(async ({ config: cPath, verbose, build: shouldBuild, watch }) => {
     if (!watch && !shouldBuild) {
         console.error("Options --no-build can only be specified with --watch.");

--- a/dist/main.js
+++ b/dist/main.js
@@ -1,92 +1,57 @@
 #!/usr/bin/env node
 import { program } from "commander";
-import { build, buildAll, compilationMap, includeBuiltModules } from "./compile.js";
+import { buildFile, buildAll, buildMap } from "./compile.js";
 import { defaultConfig, importConfig, logger } from "./config.js";
 import * as chokidar from "chokidar";
 import * as pt from "path";
 import * as _fs from "fs-extra";
 const fs = _fs.default;
-program.name("svbuild").option("-s, --src <path>", "Compile files from this directory")
-    .option("-o, --out <path>", "Compile files to this directory")
-    .option("-c, --config <path>", "Path to the configuration file")
+program.name("svbuild")
+    .option("-c, --config <path>", "Path to the configuration file", './svbuild.config.js')
     .option("-v, --verbose", "Log internal information")
-    .option("-R, --rebuild", "Rebuild modules in out dir.")
-    .action(async ({ src, out, config: cPath, verbose, rebuild }) => {
+    .option("-w, --watch", "Watch the src directory for changes")
+    .option("-B, --no-build", "Don't build everything at first, only works with --watch")
+    .action(async ({ config: cPath, verbose, build: shouldBuild, watch }) => {
+    if (!watch && !shouldBuild) {
+        console.error("Options --no-build can only be specified with --watch.");
+        process.exit(1);
+    }
     await importConfig(cPath);
-    out = config.out || out;
-    src = config.src || src;
     config.compilerOptions ||= Object.assign(defaultConfig.compilerOptions, config.compilerOptions);
     if (config.moduleOptions) {
         config.moduleOptions = Object.assign(defaultConfig.moduleOptions, config.moduleOptions);
-        if (!rebuild) {
-            includeBuiltModules(config.moduleOptions.root);
-        }
     }
     global.verbose = verbose;
-    if (!out || !src) {
-        console.error(`Directories "out" and/or "src" are not specified.`);
-        process.exit(1);
-    }
     if (config.compilerOptions?.esm == false && config.moduleOptions) {
         console.error(`compilerOptions.esm cannot be %o with config.moduleOptions`, false);
         process.exit(1);
     }
-    buildAll(src, out);
-});
-program.command("watch").description("Watches the src directory for changes")
-    .option("-s, --src <path>", "Compile files from this directory")
-    .option("-o, --out <path>", "Compile files to this directory")
-    .option("-c, --config <path>", "Path to the configuration file")
-    .option("-b, --no-build", "Don't build everything at first")
-    .option("-v, --verbose", "Log internal information")
-    .action(async ({ src, out, config: cPath, verbose, build: shouldBuild }) => {
-    await importConfig(cPath);
-    out = out || config.out;
-    src = src || config.src;
-    config.compilerOptions ||= Object.assign(defaultConfig.compilerOptions, config.compilerOptions);
-    if (config.moduleOptions) {
-        config.moduleOptions = Object.assign(defaultConfig.moduleOptions, config.moduleOptions);
-    }
-    global.verbose = verbose;
-    if (!out || !src) {
-        console.error(`Directories "out" and/or "src" are not specified.`);
-        process.exit(1);
-    }
-    if (!(config.compilerOptions?.esm) && config.moduleOptions) {
-        console.error(`compilerOptions.esm cannot be %o with config.moduleOptions`, false);
-        process.exit(1);
-    }
     if (shouldBuild) {
-        buildAll(src, out);
+        buildAll(config.src);
     }
-    const watcher = chokidar.watch('.', { atomic: true, cwd: src, persistent: true });
+    if (!watch)
+        return;
+    const watcher = chokidar.watch('.', { atomic: true, cwd: config.src, persistent: true });
     watcher.on('ready', () => {
-        console.log('Watching', src);
+        console.log('Watching', config.src);
         watcher.on('add', (path) => {
-            let from = pt.join(src, path);
-            let dest = pt.join(out, path);
+            let from = pt.join(config.src, path);
+            let dest = pt.join(config.out, path);
             console.log(`Building`, dest);
-            build(buildAll, from, dest, (e) => {
-                console.error(`Error while building "${path}" to "${dest}".\nError:`, e);
-            });
-        });
-        watcher.on('addDir', (path) => {
-            if (!path)
-                return;
-            path = pt.join(src, path);
-            let dest = pt.join(out, path);
-            buildAll(path, dest);
+            buildFile(from);
         });
         watcher.on('unlink', (path) => {
             if (!path)
                 return;
-            path = pt.join(src, path);
-            if (path in compilationMap) {
-                const map = compilationMap[path];
-                logger(`Unlinking "${map.path}" for "${path}"`);
-                console.log(`Removing`, map.path);
-                fs.rmSync(map.path + (map.type == 'svelte' ? '.js' : ''), { recursive: true });
-                delete compilationMap[path];
+            path = pt.join(config.src, path);
+            if (path in buildMap) {
+                const built = buildMap[path];
+                if (!built)
+                    return;
+                logger(`Unlinking "${built}" for "${path}"`);
+                console.log(`Removing`, built);
+                fs.rmSync(built, { recursive: true });
+                delete buildMap[path];
                 return;
             }
             logger(`no unlink for ${path}`);
@@ -94,12 +59,14 @@ program.command("watch").description("Watches the src directory for changes")
         watcher.on('unlinkDir', (path) => {
             if (!path)
                 return;
-            path = pt.join(src, path);
-            if (path in compilationMap) {
-                const map = compilationMap[path];
-                logger(`Unlinking "${map.path}" for "${path}"`);
-                console.log(`Removing`, map.path);
-                fs.rmSync(map.path, { recursive: true });
+            path = pt.join(config.src, path);
+            if (path in buildMap) {
+                const built = buildMap[path];
+                if (!built)
+                    return;
+                logger(`Unlinking "${built}" for "${path}"`);
+                console.log(`Removing`, built);
+                fs.rmSync(built, { recursive: true });
                 return;
             }
             logger(`no unlink for ${path}`);
@@ -107,22 +74,37 @@ program.command("watch").description("Watches the src directory for changes")
         watcher.on('change', (path) => {
             if (!path)
                 return;
-            let from = pt.join(src, path);
-            if (from in compilationMap) {
-                const map = compilationMap[from];
-                logger(`Changing "${map.path}" for "${from}"`);
-                console.log(`Building`, map.path);
-                build(buildAll, from, map.path, (e) => {
-                    console.error(`Error while building "${from}" to "${map.path}".\nError:`, e);
-                });
+            let from = pt.join(config.src, path);
+            map: if (from in buildMap) {
+                const built = buildMap[from];
+                logger(`Changing "${built}" for "${from}"`);
+                if (!built)
+                    break map;
+                console.log(`Building`, built);
+                buildFile(from);
                 return;
             }
-            let dest = pt.join(out, path);
+            let dest = pt.join(config.out, path);
             console.log(`Building`, dest);
-            build(buildAll, from, dest, (e) => {
-                console.error(`Error while building "${path}" to "${dest}".\nError:`, e);
-            });
+            buildFile(from);
         });
     });
+});
+program.command("watch").description("Watches the src directory for changes")
+    .option("-c, --config <path>", "Path to the configuration file", './svbuild.config.js')
+    .option("-v, --verbose", "Log internal information")
+    .option("-B, --no-build", "Don't build everything at first")
+    .action(async ({ config: cPath, verbose, build: shouldBuild }) => {
+    console.log(process.argv, { config: cPath, verbose, build: shouldBuild });
+    await importConfig(cPath);
+    config.compilerOptions ||= Object.assign(defaultConfig.compilerOptions, config.compilerOptions);
+    if (config.moduleOptions) {
+        config.moduleOptions = Object.assign(defaultConfig.moduleOptions, config.moduleOptions);
+    }
+    global.verbose = verbose;
+    if (!(config.compilerOptions?.esm) && config.moduleOptions) {
+        console.error(`compilerOptions.esm cannot be %o with config.moduleOptions`, false);
+        process.exit(1);
+    }
 });
 program.parse();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "svbuild",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "svbuild",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
         "acorn": "^8.7.1",
         "chalk": "^5.0.1",
         "chokidar": "^3.5.3",
-        "commander": "^9.2.0",
+        "commander": "^9.4.0",
         "fs-extra": "^10.1.0",
         "svelte": "^3.46.4",
         "url-join": "^5.0.0"
@@ -119,9 +119,9 @@
       }
     },
     "node_modules/commander": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
-      "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
+      "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -358,9 +358,9 @@
       }
     },
     "commander": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
-      "integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w=="
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
+      "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw=="
     },
     "fill-range": {
       "version": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "acorn": "^8.7.1",
     "chalk": "^5.0.1",
     "chokidar": "^3.5.3",
-    "commander": "^9.2.0",
+    "commander": "^9.4.0",
     "fs-extra": "^10.1.0",
     "svelte": "^3.46.4",
     "url-join": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "svbuild",
-  "version": "0.1.0",
-  "description": "[beta] A simple tool that builds your svelte files without bundling them.",
+  "version": "2.0.0",
+  "description": "A simple tool that builds your svelte files without bundling them.",
   "main": "dist/main.js",
   "scripts": {
     "build": "tsc"

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,8 +2,8 @@ import * as pt from "path";
 import { Config } from "../types";
 
 export const defaultConfig: Config = {
-  src: '',
-  out: '',
+  src: 'src',
+  out: 'out',
   compilerOptions: {
     dev: true,
     esm: true,
@@ -13,21 +13,39 @@ export const defaultConfig: Config = {
     root: "modules",
     buildModules: false,
     modulesSrc: 'node_modules',
-    buildSvelte: false
+    buildSvelte: false,
+    usePreprocessorsWithModules: false,
+    preferredResolutionType: {}
   }
 }
 
-export async function importConfig(path: string = './svbuild.config.js') {
-  path = pt.resolve(path)
-  
+let configPath: string;
+export const resolveFromConfig = (path: string) => pt.join(pt.dirname(configPath), path)
+
+export async function importConfig(path: string) {
+  configPath = pt.resolve(path)
+
   try {
-    let c = await import('file:///' + path.replaceAll('\\', '/'));
+    let c = await import('file:///' + configPath.replaceAll('\\', '/'));
     global.config = c.default
     
   } catch (_) {
     console.log("Configuration file not found.");
-    global.config = defaultConfig
+    process.exit(1)
   }
+  if (!('moduleOptions' in config)) {
+    config.moduleOptions = defaultConfig.moduleOptions;
+  }
+  if (!config.moduleOptions.preferredResolutionType) {
+    config.moduleOptions.preferredResolutionType = defaultConfig.moduleOptions.preferredResolutionType;
+  }
+  if (!config.moduleOptions.usePreprocessorsWithModules) {
+    config.moduleOptions.usePreprocessorsWithModules = defaultConfig.moduleOptions.usePreprocessorsWithModules;
+  }
+
+  config.src = resolveFromConfig(config.src);
+  config.out = resolveFromConfig(config.out);
+  config.moduleOptions.modulesSrc = resolveFromConfig(config.moduleOptions.modulesSrc);
 }
 
 export function logger(...info: any[]) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ program.name("svbuild")
   .option("-c, --config <path>", "Path to the configuration file", './svbuild.config.js')
   .option("-v, --verbose", "Log internal information")
   .option("-w, --watch", "Watch the src directory for changes")
-  .option("-B, --no-build", "Don't build everything at first, only works with --watch")
+  .option("-B, --no-build", "Don't build the project at first, only works with --watch")
   .action(async({ config: cPath, verbose, build: shouldBuild, watch }) => {
     if (!watch && !shouldBuild) {
       console.error("Options --no-build can only be specified with --watch.");

--- a/src/main.ts
+++ b/src/main.ts
@@ -110,30 +110,4 @@ program.name("svbuild")
   })
 ;
 
-
-program.command("watch").description("Watches the src directory for changes")
-  .option("-c, --config <path>", "Path to the configuration file", './svbuild.config.js')
-  .option("-v, --verbose", "Log internal information")
-  .option("-B, --no-build", "Don't build everything at first")
-  .action(async({ config: cPath, verbose, build: shouldBuild }) => {
-    console.log(process.argv, {config: cPath, verbose, build: shouldBuild});
-
-    await importConfig(cPath);
-
-    config.compilerOptions ||= Object.assign(defaultConfig.compilerOptions, config.compilerOptions);
-    if (config.moduleOptions) {
-      config.moduleOptions = Object.assign(defaultConfig.moduleOptions, config.moduleOptions);
-    }
-
-    global.verbose = verbose
-
-    if (!(config.compilerOptions?.esm) && config.moduleOptions) {
-      console.error(`compilerOptions.esm cannot be %o with config.moduleOptions`, false);
-      process.exit(1)
-    }
-
-
-  })
-;
-
 program.parse();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { program } from "commander";
 import type { Config } from "../types";
-import { build, buildAll, compilationMap, includeBuiltModules } from "./compile.js";
+import { buildFile, buildAll, buildMap } from "./compile.js";
 import { defaultConfig, importConfig, logger } from "./config.js";
 import * as chokidar from "chokidar";
 import * as pt from "path";
@@ -14,118 +14,75 @@ declare global {
   var verbose: boolean
 }
 
-program.name("svbuild").option("-s, --src <path>", "Compile files from this directory")
-  .option("-o, --out <path>", "Compile files to this directory")
-  .option("-c, --config <path>", "Path to the configuration file")
+program.name("svbuild")
+  .option("-c, --config <path>", "Path to the configuration file", './svbuild.config.js')
   .option("-v, --verbose", "Log internal information")
-  .option("-R, --rebuild", "Rebuild modules in out dir.")
-  .action(async({ src, out, config: cPath, verbose, rebuild }) => {
+  .option("-w, --watch", "Watch the src directory for changes")
+  .option("-B, --no-build", "Don't build everything at first, only works with --watch")
+  .action(async({ config: cPath, verbose, build: shouldBuild, watch }) => {
+    if (!watch && !shouldBuild) {
+      console.error("Options --no-build can only be specified with --watch.");
+      process.exit(1)
+    }
     await importConfig(cPath);
-    out = config.out || out
-    src = config.src || src
 
     config.compilerOptions ||= Object.assign(defaultConfig.compilerOptions, config.compilerOptions);
     if (config.moduleOptions) {
       config.moduleOptions = Object.assign(defaultConfig.moduleOptions, config.moduleOptions);
-
-      if (!rebuild) {
-        includeBuiltModules(config.moduleOptions.root)
-      }
     }
 
     global.verbose = verbose
-
-    if (!out || !src) {
-      console.error(`Directories "out" and/or "src" are not specified.`);
-      process.exit(1)
-    }
 
     if (config.compilerOptions?.esm == false && config.moduleOptions) {
       console.error(`compilerOptions.esm cannot be %o with config.moduleOptions`, false);
       process.exit(1)
     }
 
-    buildAll(src, out)
-  })
-;
-
-
-program.command("watch").description("Watches the src directory for changes")
-  .option("-s, --src <path>", "Compile files from this directory")
-  .option("-o, --out <path>", "Compile files to this directory")
-  .option("-c, --config <path>", "Path to the configuration file")
-  .option("-b, --no-build", "Don't build everything at first")
-  .option("-v, --verbose", "Log internal information")
-  .action(async({ src, out, config: cPath, verbose, build: shouldBuild }) => {
-    await importConfig(cPath);
-    out = out || config.out
-    src = src || config.src
-
-    config.compilerOptions ||= Object.assign(defaultConfig.compilerOptions, config.compilerOptions);
-    if (config.moduleOptions) {
-      config.moduleOptions = Object.assign(defaultConfig.moduleOptions, config.moduleOptions);
-    }
-
-    global.verbose = verbose
-
-    if (!out || !src) {
-      console.error(`Directories "out" and/or "src" are not specified.`);
-      process.exit(1)
-    }
-
-    if (!(config.compilerOptions?.esm) && config.moduleOptions) {
-      console.error(`compilerOptions.esm cannot be %o with config.moduleOptions`, false);
-      process.exit(1)
-    }
-
     if (shouldBuild) {
-      buildAll(src, out)
+      buildAll(config.src)
     }
 
-    const watcher = chokidar.watch('.', { atomic: true, cwd: src, persistent: true });
+    if (!watch) return;
+
+    const watcher = chokidar.watch('.', { atomic: true, cwd: config.src, persistent: true });
 
     watcher.on('ready', () => {
-      console.log('Watching', src)
+      console.log('Watching', config.src)
       watcher.on('add', (path) => {
-        let from = pt.join(src, path)
-        let dest = pt.join(out, path);
+        let from = pt.join(config.src, path)
+        let dest = pt.join(config.out, path);
 
         console.log(`Building`, dest);
-        build(buildAll, from, dest, (e) => {
-          console.error(`Error while building "${path}" to "${dest}".\nError:`, e)
-        })
-      });
-      watcher.on('addDir', (path) => {
-        if (!path) return;
-  
-        path = pt.join(src, path);
-        let dest = pt.join(out, path);
-        buildAll(path, dest)
+        buildFile(from)
       });
   
       watcher.on('unlink', (path) => {
         if (!path) return;
-        path = pt.join(src, path);
+        path = pt.join(config.src, path);
   
-        if (path in compilationMap) {
-          const map = compilationMap[path];
-          logger(`Unlinking "${map.path}" for "${path}"`);
-          console.log(`Removing`, map.path);
-          fs.rmSync(map.path + (map.type == 'svelte' ? '.js' : ''), { recursive: true })
-          delete compilationMap[path]
+        if (path in buildMap) {
+          const built = buildMap[path];
+          if (!built) return;
+
+          logger(`Unlinking "${built}" for "${path}"`);
+          console.log(`Removing`, built);
+          fs.rmSync(built, { recursive: true })
+          delete buildMap[path]
           return;
         }
         logger(`no unlink for ${path}`);
       })
       watcher.on('unlinkDir', (path) => {
         if (!path) return;
-        path = pt.join(src, path);
+        path = pt.join(config.src, path);
   
-        if (path in compilationMap) {
-          const map = compilationMap[path];
-          logger(`Unlinking "${map.path}" for "${path}"`);
-          console.log(`Removing`, map.path);
-          fs.rmSync(map.path, { recursive: true })
+        if (path in buildMap) {
+          const built = buildMap[path];
+          if (!built) return;
+
+          logger(`Unlinking "${built}" for "${path}"`);
+          console.log(`Removing`, built);
+          fs.rmSync(built, { recursive: true })
           return;
         }
         logger(`no unlink for ${path}`);
@@ -133,26 +90,48 @@ program.command("watch").description("Watches the src directory for changes")
   
       watcher.on('change', (path) => {
         if (!path) return;
-        let from = pt.join(src, path);
+        let from = pt.join(config.src, path);
   
-        if (from in compilationMap) {
-          const map = compilationMap[from];
-          logger(`Changing "${map.path}" for "${from}"`);
-  
-          console.log(`Building`, map.path);
-          build(buildAll, from, map.path, (e) => {
-            console.error(`Error while building "${from}" to "${map.path}".\nError:`, e)
-          })
+        map: if (from in buildMap) {
+          const built = buildMap[from];
+          logger(`Changing "${built}" for "${from}"`);
+          if (!built) break map;
+
+          console.log(`Building`, built);
+          buildFile(from)
           return;
         }
-        let dest = pt.join(out, path);
+        let dest = pt.join(config.out, path);
 
         console.log(`Building`, dest);
-        build(buildAll, from, dest, (e) => {
-          console.error(`Error while building "${path}" to "${dest}".\nError:`, e)
-        })
+        buildFile(from)
       })
     })
+  })
+;
+
+
+program.command("watch").description("Watches the src directory for changes")
+  .option("-c, --config <path>", "Path to the configuration file", './svbuild.config.js')
+  .option("-v, --verbose", "Log internal information")
+  .option("-B, --no-build", "Don't build everything at first")
+  .action(async({ config: cPath, verbose, build: shouldBuild }) => {
+    console.log(process.argv, {config: cPath, verbose, build: shouldBuild});
+
+    await importConfig(cPath);
+
+    config.compilerOptions ||= Object.assign(defaultConfig.compilerOptions, config.compilerOptions);
+    if (config.moduleOptions) {
+      config.moduleOptions = Object.assign(defaultConfig.moduleOptions, config.moduleOptions);
+    }
+
+    global.verbose = verbose
+
+    if (!(config.compilerOptions?.esm) && config.moduleOptions) {
+      console.error(`compilerOptions.esm cannot be %o with config.moduleOptions`, false);
+      process.exit(1)
+    }
+
 
   })
 ;

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -1,6 +1,8 @@
 import * as _fs from "fs-extra";
-import * as pt from "path";
+import * as p from "path";
+import c from "chalk";
 import urlJoin from "url-join";
+import { parse } from "url";
 
 const fs = (_fs as any).default as typeof _fs
 
@@ -15,87 +17,110 @@ export function prepareJSPath(path: string) {
 
 /** Joiner that supports URLs */
 export function betterJoin(segment1: string, ...paths: string[]) {
-  paths = paths.map(p => pt.normalize(p)).filter(p => p != '/'); // don't normalize the 1st segment that contains the url
+  paths = paths.map(p => p.normalize(p)).filter(p => p != '/'); // don't normalize the 1st segment that contains the url
   return urlJoin(segment1, ...paths)
 }
 
-export function resolveImport(dep: string, initialPath: string, relativePath: string) {
-  let firstSegment = dep.split('/')[0];
-  let stripped = dep.replace(firstSegment, '').slice(1); // slice(1) removes the slash
+function isURL(path: string) {
+  return !!parse(path).protocol;
+}
 
-  let package_json: any;
-  try {
-    package_json = JSON.parse(fs.readFileSync(pt.join(config.moduleOptions.modulesSrc, firstSegment, 'package.json'), 'utf-8'));
+function parsePackageJSON(contents: any, moduleName: string, otherSegments: string, resolution?: string) {
+  if ('exports' in contents) {
+    function analyzeExports(exportsField: any) {
+      if (typeof exportsField == 'string') return exportsField;
+      for (const key in exportsField) {
+        const element = exportsField[key];
+        if (key.startsWith('./')) {
+          if (p.normalize(key) != otherSegments) continue;
+          if (typeof element == 'string') {
+            return element;
 
-  } catch (e) {
-    console.error(`[BUILD WARNING] Unable to resolve "${dep}". Check if you have the dependency installed.\n  Error:`, e.message)
-    return initialPath;
-  }
-
-  if (firstSegment == dep) {
-    let { main, module: _module, exports: _exports } = package_json;
-
-    if (!_exports || typeof _exports != 'object') {
-      return prepareJSPath(pt.join(initialPath, _module || main || 'index.js'))
-    }
-
-    let exportedMod_any = _exports['.'];
-    let exportedMod: string;
-
-    if (typeof exportedMod_any == 'string') {
-      exportedMod = exportedMod_any;
-    } else {
-      exportedMod = exportedMod_any.import
-    }
-
-    let final = exportedMod ? pt.join(relativePath, exportedMod) : pt.join(initialPath, _module || main || 'index.js')
-    return prepareJSPath(final);
-
-  } else {
-    let index = 'index.js';
-    let { exports: _exports } = package_json;
-
-    if (!_exports || typeof _exports != 'object') {
-      return prepareJSPath(pt.join(initialPath, index))
-    }
-
-    let normalized = pt.normalize(stripped).replaceAll('\\', '/');
-    let exportedMod_any = _exports[normalized] || _exports['./' + normalized];
-
-    let exportedMod: string;
-
-    if (exportedMod_any == undefined) {
-      let separated = stripped.split('/');
-
-      let prevSegments = [];
-      for (const segment of separated) {
-        let joined = prevSegments.join('/');
-
-        let normalized = pt.normalize((joined ? (joined + '/') : '') + stripped).replaceAll('\\', '/');
-        exportedMod_any =
-          _exports[normalized] ||
-          _exports['./' + normalized]
-        ;
-
-        if (exportedMod_any) {
-          break;
+          } else {
+            return analyzeExports(element)
+          }
+        } else {
+          if (key == resolution || key == 'import') {
+            return analyzeExports(element)
+          }
         }
+      }
+      if ('default' in exportsField) {
+        return analyzeExports(exportsField.default)
+      }
 
-        prevSegments.push(segment)
+      throw `The "exports" field is invalid.`;
+    }
+
+    if (typeof contents.exports == 'string') {
+      return contents.exports
+
+    } else {
+      if (!contents.exports['.']) throw `Invalid exports field in package.json of module "${moduleName}"`;
+
+      if (otherSegments == '') {
+        return analyzeExports(contents.exports['.'])
+
+      } else {
+        return analyzeExports(contents.exports)
       }
     }
 
-    if (typeof exportedMod_any == 'string') {
-      exportedMod = exportedMod_any;
+  } else {
+    return contents.module || contents.main;
+  }
+}
 
-    } else if (exportedMod_any == undefined) {
-      console.error(`[BUILD WARNING] Unable to find exports for "${dep}". Using "${pt.join(initialPath, index)}"`);
+async function resolveModule(modulePath: string, resolution?: string) {
+  try {
+    const moduleName = modulePath.split('/')[0]
+    const otherSegments = modulePath.split('/').slice(1).join('/')
 
-    } else {
-      exportedMod = exportedMod_any.import // get es6 export
+    let packageJSONLocation = p.join(config.moduleOptions.modulesSrc, moduleName, 'package.json');
+
+    if (!(await fs.pathExists(packageJSONLocation))) {
+      throw `package.json for module "${moduleName}" \
+(in ${p.join(config.moduleOptions.modulesSrc, moduleName, 'package.json')}) \
+doesn't exist. ${
+        moduleName.includes('.') ? "If you want to import a local file, prepend it with `./`." : ''
+      }`;
     }
 
-    let final = exportedMod ? pt.join(relativePath, exportedMod) : pt.join(initialPath, index)
-    return prepareJSPath(final);
+    const packageJSON = JSON.parse(await fs.readFile(packageJSONLocation, 'utf-8'));
+
+    return {
+      path: p.join(p.dirname(packageJSONLocation), parsePackageJSON(packageJSON, moduleName, otherSegments, resolution)),
+      moduleName
+    }
+
+  } catch (error) {
+    console.error(c.red("[ERROR]"), `while resolving "${modulePath}":`, error + '')
+    return { path: modulePath, moduleName: '<unknown>' };
+  }
+}
+
+export async function resolveDependency(from: string, path: string): Promise<{path: string, moduleName?: string} | null> {
+  if (isURL(path) || path.startsWith('/')) {
+    if (p.extname(path) == "") path += ".js";
+    return null;
+  }
+
+  if (path.startsWith('.')) {
+    if (p.extname(path) == '') path += '.js';
+    return { path: p.join(p.dirname(from), path) }
+
+  } else {
+    let resolution: string;
+    let moduleName = path.split('/')[0];
+
+    if (config.moduleOptions.preferredResolutionType) {
+      if (moduleName in config.moduleOptions.preferredResolutionType) {
+        resolution = config.moduleOptions.preferredResolutionType[moduleName]
+      }
+    }
+
+    if (moduleName == 'svelte' && !config.moduleOptions.buildSvelte) return { path: '', moduleName }
+
+    return await resolveModule(path, resolution);
   }
 }

--- a/test/svbuild.config.js
+++ b/test/svbuild.config.js
@@ -14,7 +14,7 @@ const config = {
     typescript: {}
   }),
   moduleOptions: {
-    root: './out/m',
+    root: 'm',
     buildModules: true,
     buildSvelte: true,
     modulesSrc: 'node_modules'

--- a/test/svelte/App.svelte
+++ b/test/svelte/App.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
 	import Counter from "./components/Counter.svelte";
 	import { TextBox } from "fluent-svelte";
+	import { setContext } from "svelte";
 
 	type Name = {
 		value: string
 	}
 	let name: Name = { value: 'world' };
+
+	setContext('msg', 'Hi')
 </script>
 
 {#if name.value}

--- a/test/svelte/components/Counter.svelte
+++ b/test/svelte/components/Counter.svelte
@@ -1,8 +1,10 @@
 <script>
   import { Button } from "fluent-svelte";
+  import { getContext } from "svelte"
 
   export let count = 0;
 
+  let message = getContext('msg')
 </script>
 
 <Button on:click={ () => { count--; } }> - </Button>
@@ -12,3 +14,6 @@
 </Button>
 
 <Button variant="hyperlink" on:click={ () => { count++; } }> + </Button>
+
+
+Message: {message}

--- a/test/svelte/index.html
+++ b/test/svelte/index.html
@@ -1,0 +1,7 @@
+<script type="module">
+  import App from "./App.svelte.js";
+
+  window.app = new App({
+    target: document.body
+  })
+</script>

--- a/types.d.ts
+++ b/types.d.ts
@@ -28,14 +28,22 @@ export type Config = {
   /** Options for the module resolver. This **must not** be defined if `compilerOptions.esm` is `false` */
   moduleOptions?: {
     /** The folder where the compiled modules are or will be built to.
-     * > Note: this path is relative to the CWD, not to the `out` directory */
-    root?: string,
+     * > Note: this path is relative to the `out` directory */
+    root?: string
     /** Whether svbuild should build all the dependencies */
-    buildModules?: boolean,
-    /** Path to the folder, from which the dependencies are taken from. Default is `./node_modules`
+    buildModules?: boolean
+    /** Path to the folder, from which the dependencies are taken from. Default is `"node_modules"`
      * @default "node_modules" */
-    modulesSrc?: string,
+    modulesSrc?: string
     /** Whether svbuild should build svelte like a regular dependency */
     buildSvelte?: boolean
+    /** Whether svbuild should preprocess module code. Can be either set to boolean, or to an object with module names as keys. */
+    usePreprocessorsWithModules?: boolean | {
+      [moduleName: string]: string
+    }
+    /** The preferred type of the `exports` field. Is usually `"browser"`, but can be set to anything else if that's causing problems */
+    preferredResolutionType?: {
+      [moduleName: string]: string
+    }
   }
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,7 +1,7 @@
 import { PreprocessorGroup } from "svelte/types/compiler/preprocess"
 
 /**
- * Configuration for `svbuild`. All paths are relative to CWD.
+ * Configuration for `svbuild`. All paths are relative to this file, unless specified otherwise.
  */
 export type Config = {
   /** Path to source directory with svelte code */


### PR DESCRIPTION
## Changelog:

- Now, svbuild only builds files that are actually imported, even in modules.
- Added more configuration options: `usePreprocessorsWithModules` and `preferredResolutionType`. They also can be set per module.
- All paths are now resolved from the configuration file, and not from CWD. (except for `root`, it is resolved from the `out` folder)
- Rewrote the way svbuild builds all files for better maintainability.
- Rewrote the way svbuild resolves modules and dependencies.
- Better documentation.
- Removed the `watch` command, as it was causing some bugs. Instead of this command there is now a `--watch` option.